### PR TITLE
stringify all dict keys

### DIFF
--- a/laser_prynter/pp.py
+++ b/laser_prynter/pp.py
@@ -22,9 +22,18 @@ def _print(s: str, **kwargs) -> None:
 def _isnamedtuple(obj: object):
     return isinstance(obj, tuple) and hasattr(obj, '_fields')
 
+def _normalise_keys(d: dict):
+    'norlimalise dict keys for JSON by stringifying'
+    for k,v in d.items():
+        if not isinstance(k, str):
+            yield str(k), _normalise(v)
+        else:
+            yield k, _normalise(v)
+
 def _normalise(obj: object):
     'step through obj and normalise namedtuples to dicts'
-    if isinstance(obj, dict): return {k: _normalise(v) for k, v in obj.items()}
+    if isinstance(obj, dict):
+        return dict(_normalise_keys(obj))
     if isinstance(obj, list): return [_normalise(i) for i in obj]
     if _isnamedtuple(obj):    return obj._asdict()
     return obj

--- a/test/pp/test_pp.py
+++ b/test/pp/test_pp.py
@@ -99,16 +99,29 @@ class TestJSONDefault:
 
         assert s.getvalue().strip() == '{"a": "t"}'
 
+    def test_tuple_keys(self):
+        'Print a dict with tuple keys as JSON'
+
+        s = StringIO()
+        pp.ppd({('a', 'b'): 'c'}, indent=None, style=None, file=s)
+
+        assert s.getvalue().strip() == '{"(\'a\', \'b\')": "c"}'
+
+
 
 class TestNormalise:
 
     def test_is_namedtuple(self):
+        'Detect if an object is a namedtuple'
+
         Testr = namedtuple('testr', ('a', 'b'))
         t = Testr(1,2)
 
         assert pp._isnamedtuple(t) is True
 
     def test_normalise(self):
+        'Normalise namedtuples into dicts'
+
         Testr = namedtuple('testr', ('a', 'b'))
 
         result = pp._normalise({


### PR DESCRIPTION
This normalises dictionaries with tuple keys for JSON by stringifying them

e.g.

```python
{
  ('a', 'b'): 'c'
}
```

becomes
```json
{
  "('a', 'b')": "c"
}
```