### PR TITLE
lower minimum supported python version to 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "terminal/cli/python helpers for colour and pretty-printing"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.12"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This repo totally supports 3.12 just fine, and that seems to be the highest version currently installable on debian, so I'm lowering it from 3.13 > 3.12 to make my life easier