### PR TITLE
Faster testing

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -8,8 +8,13 @@ RUFF_STATUS=0
 MYPY_STATUS=0
 TEST_STATUS=0
 
+echo -e "\n\e[1;97mRunning pre-commit checks on staged Python files:\e[0m\n$fpaths\n"
+
+echo -e "\e[1;93m> ruff check\e[0m"
 ruff check $fpaths || RUFF_STATUS=$?
+echo -e "\n\e[1;93m> mypy\e[0m"
 mypy $fpaths || MYPY_STATUS=$?
+echo -e "\n\e[1;93m> unittest\e[0m"
 python3 -m unittest discover -s test || TEST_STATUS=$?
 
 [ $RUFF_STATUS -eq 0 ] && [ $MYPY_STATUS -eq 0 ] && [ $TEST_STATUS -eq 0 ] || exit 1

--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -6,8 +6,10 @@ fpaths=$(git diff --name-only --cached --diff-filter=ACM | grep '.py' | tr '\n' 
 
 RUFF_STATUS=0
 MYPY_STATUS=0
+TEST_STATUS=0
 
 ruff check $fpaths || RUFF_STATUS=$?
 mypy $fpaths || MYPY_STATUS=$?
+python3 -m unittest discover -s test || TEST_STATUS=$?
 
-[ $RUFF_STATUS -eq 0 ] && [ $MYPY_STATUS -eq 0 ] || exit 1
+[ $RUFF_STATUS -eq 0 ] && [ $MYPY_STATUS -eq 0 ] && [ $TEST_STATUS -eq 0 ] || exit 1

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v1
+      uses: astral-sh/setup-uv@v7
     - name: uv sync
       run: uv sync --locked --all-groups
     - name: unittest

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,22 +1,17 @@
-name: ruff
+name: test
 on: [push]
 
 jobs:
-  ruff:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Ruff Check
-        uses: astral-sh/ruff-action@v1
-        with:
-          args: check
-  test:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Install uv
-      uses: astral-sh/setup-uv@v7
-    - name: uv sync
-      run: uv sync --locked --all-groups
-    - name: unittest
-      run: uv run python3 -m unittest discover -s test
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: uv sync
+        run: uv sync --locked --all-groups
+      - name: ruff check
+        run: uv run ruff check
+      - name: unittest
+        run: uv run python3 -m unittest discover -s test

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -11,3 +11,12 @@ jobs:
         uses: astral-sh/ruff-action@v1
         with:
           args: check
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install uv
+      uses: astral-sh/setup-uv@v1
+    - name: uv sync
+      run: uv sync --locked --all-groups
+    - name: unittest
+      run: uv run python3 -m unittest discover -s test

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-build/pypi:
-	rm -rf build/ dist/ laser_prynter.egg-info/
-	python3 -m build --wheel --sdist
-	python3 -m twine check dist/*
+pypi/build:
+	uv build
 	
+pypi/publish:
+	tree dist/
 	@echo -e "\e[93mPress [Enter] to continue uploading to PyPI...\e[0m"
 	@read 
 	twine upload dist/*
 
-.PHONY: build/pypi
+test:
+	python3 -m unittest discover -s test
+
+.PHONY: pypi/build pypi/publish test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ Homepage = "https://github.com/tmck-code/laser-prynter"
 Issues = "https://github.com/tmck-code/laser-prynter/issues"
 
 [tool.ruff]
-exclude = ["bin/", ".venv/", "test/"]
+exclude = ["bin/", ".venv/"]
 line-length = 100
 preview = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
 dev = [
   "build",
   "mypy",
-  "pytest",
   "ruff",
   "twine",
 ]

--- a/test/pp/test_c.py
+++ b/test/pp/test_c.py
@@ -1,6 +1,8 @@
+import unittest
+
 from laser_prynter.colour import c
 
-class TestC:
+class TestC(unittest.TestCase):
     def test_ansi_to_rgb(self) -> None:
         expected = {
             16: (0,0,0), 17: (0,0,95), 18: (0,0,135), 19: (0,0,175), 20: (0,0,215), 21: (0,0,255), 22: (0,95,0),
@@ -29,4 +31,4 @@ class TestC:
         for n in range(16, 132):
             results[n] = c.ansi_to_rgb(n)
 
-        assert results == expected
+        self.assertEqual(results, expected)

--- a/test/pp/test_pp.py
+++ b/test/pp/test_pp.py
@@ -1,18 +1,19 @@
-from laser_prynter import pp
-
+import unittest
 from collections import namedtuple
 from dataclasses import dataclass
 from datetime import datetime
 from io import StringIO
 
-class TestJSONDefault:
+from laser_prynter import pp
+
+class TestJSONDefault(unittest.TestCase):
     def test_str(self) -> None:
         'Print a dict as JSON'
 
         s = StringIO()
         pp.ppd({'a': 'b'}, indent=None, style=None, file=s)
 
-        assert s.getvalue().strip() == '{"a": "b"}'
+        self.assertEqual(s.getvalue().strip(), '{"a": "b"}')
 
     def test_dataclass(self) -> None:
         'Print a dataclass as JSON'
@@ -24,7 +25,7 @@ class TestJSONDefault:
 
         pp.ppd(A('b'), indent=None, style=None, file=s)
 
-        assert s.getvalue().strip() == '{"a": "b"}'
+        self.assertEqual(s.getvalue().strip(), '{"a": "b"}')
 
     def test_datetime(self) -> None:
         'Print a datetime as JSON'
@@ -32,7 +33,7 @@ class TestJSONDefault:
         s = StringIO()
         pp.ppd({'a': datetime(2021, 1, 1, 12, 34, 56)}, indent=None, style=None, file=s)
 
-        assert s.getvalue().strip() == '{"a": "2021-01-01T12:34:56"}'
+        self.assertEqual(s.getvalue().strip(), '{"a": "2021-01-01T12:34:56"}')
 
     def test_class(self) -> None:
         'Print a class instance as JSON'
@@ -44,7 +45,7 @@ class TestJSONDefault:
 
         pp.ppd({'a': A('b')}, indent=None, style=None, file=s)
 
-        assert s.getvalue().strip() == '{"a": {"a": "b"}}'
+        self.assertEqual(s.getvalue().strip(), '{"a": {"a": "b"}}')
 
     def test_function(self) -> None:
         'Print a function as JSON'
@@ -54,7 +55,7 @@ class TestJSONDefault:
 
         pp.ppd({'a': a}, indent=None, style=None, file=s)
 
-        assert s.getvalue().strip() == '{"a": "a()"}'
+        self.assertEqual(s.getvalue().strip(), '{"a": "a()"}')
 
     def test_slots(self) -> None:
         'Print a class with __slots__ as JSON'
@@ -66,7 +67,7 @@ class TestJSONDefault:
                 self.a = a
         pp.ppd({'a': A('b')}, indent=None, style=None, file=s)
 
-        assert s.getvalue().strip() == '{"a": {"a": "b"}}'
+        self.assertEqual(s.getvalue().strip(), '{"a": {"a": "b"}}')
 
     def test_namedtuple(self) -> None:
         'Print a namedtuple as JSON'
@@ -76,7 +77,7 @@ class TestJSONDefault:
 
         pp.ppd({'x': Testr(1, 2)}, indent=None, style=None, file=s)
 
-        assert s.getvalue().strip() == '{"x": {"a": 1, "b": 2}}'
+        self.assertEqual(s.getvalue().strip(), '{"x": {"a": 1, "b": 2}}')
 
     def test_list_of_namedtuple(self) -> None:
         'Print a namedtuple as JSON'
@@ -85,7 +86,7 @@ class TestJSONDefault:
         Testr = namedtuple('Testr', ('a', 'b'))
         pp.ppd([Testr(1, 2), Testr(3, 4)], indent=None, style=None, file=s)
 
-        assert s.getvalue().strip() == '[{"a": 1, "b": 2}, {"a": 3, "b": 4}]'
+        self.assertEqual(s.getvalue().strip(), '[{"a": 1, "b": 2}, {"a": 3, "b": 4}]')
 
     def test_other(self) -> None:
         'Print an object with a __str__ method as JSON'
@@ -97,7 +98,7 @@ class TestJSONDefault:
         t = Testr()
         pp.ppd({'a': t.t}, indent=None, style=None, file=s)
 
-        assert s.getvalue().strip() == '{"a": "t"}'
+        self.assertEqual(s.getvalue().strip(), '{"a": "t"}')
 
     def test_tuple_keys(self) -> None:
         'Print a dict with tuple keys as JSON'
@@ -105,11 +106,15 @@ class TestJSONDefault:
         s = StringIO()
         pp.ppd({('a', 'b'): 'c'}, indent=None, style=None, file=s)
 
-        assert s.getvalue().strip() == '{"(\'a\', \'b\')": "c"}'
+        self.assertEqual(s.getvalue().strip(), '{"(\'a\', \'b\')": "c"}')
 
 
 
-class TestArguments:
+class TestArguments(unittest.TestCase):
+
+    def tearDown(self) -> None:
+        # Reset pp.enabled to default state after each test
+        pp.enabled = True
 
     def test_enabled(self) -> None:
         'The enabled property should toggle print output on & off'
@@ -118,13 +123,13 @@ class TestArguments:
         s = StringIO()
         pp.ppd({'a': 'b'}, indent=None, style=None, file=s)
 
-        assert s.getvalue() == ''
+        self.assertEqual(s.getvalue(), '')
 
         pp.enabled = True
         s2 = StringIO()
         pp.ppd({'a': 'b'}, indent=None, style=None, file=s2)
 
-        assert s2.getvalue().strip() == '{"a": "b"}'
+        self.assertEqual(s2.getvalue().strip(), '{"a": "b"}')
 
     def test_indent(self) -> None:
         'The indent property should set the indentation level'
@@ -132,10 +137,10 @@ class TestArguments:
         s = StringIO()
         pp.ppd({'a': {'b': 'c'}}, indent=2, style=None, file=s)
 
-        assert s.getvalue().strip() == '{\n  "a": {\n    "b": "c"\n  }\n}'
+        self.assertEqual(s.getvalue().strip(), '{\n  "a": {\n    "b": "c"\n  }\n}')
 
 
-class TestNormalise:
+class TestNormalise(unittest.TestCase):
 
     def test_is_namedtuple(self) -> None:
         'Detect if an object is a namedtuple'
@@ -143,7 +148,7 @@ class TestNormalise:
         Testr = namedtuple('Testr', ('a', 'b'))
         t = Testr(1,2)
 
-        assert pp._isnamedtuple(t) is True
+        self.assertTrue(pp._isnamedtuple(t))
 
     def test_normalise(self) -> None:
         'Normalise namedtuples into dicts'
@@ -155,11 +160,11 @@ class TestNormalise:
             'y': [Testr(5, 6), Testr(3, 4)],
         })
 
-        assert result == {
+        self.assertEqual(result, {
             'x': {'a': 1, 'b': 2},
             'y': [
                 {'a': 5, 'b': 6},
                 {'a': 3, 'b': 4},
             ]
-        }
+        })
 

--- a/uv.lock
+++ b/uv.lock
@@ -189,15 +189,6 @@ wheels = [
 ]
 
 [[package]]
-name = "iniconfig"
-version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
-]
-
-[[package]]
 name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -268,7 +259,6 @@ dependencies = [
 dev = [
     { name = "build" },
     { name = "mypy" },
-    { name = "pytest" },
     { name = "ruff" },
     { name = "twine" },
 ]
@@ -280,7 +270,6 @@ requires-dist = [{ name = "pygments" }]
 dev = [
     { name = "build" },
     { name = "mypy" },
-    { name = "pytest" },
     { name = "ruff" },
     { name = "twine" },
 ]
@@ -461,15 +450,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pluggy"
-version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -494,22 +474,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
-]
-
-[[package]]
-name = "pytest"
-version = "9.0.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "iniconfig" },
-    { name = "packaging" },
-    { name = "pluggy" },
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Context

unittest runs >= 6x faster than pytest

- pytest runs in `0.318s`
    ```
     ☯ ~/d/laser-prynter time python3 -m pytest test/
    ...
    == 15 passed in 0.02s 
    
    real	0m0.318s
    user	0m0.289s
    sys	0m0.022s
    ```
- unittest runs in `0.058s`
    ```
     ☯ ~/d/laser-prynter time python3 -m unittest discover -s test/
    ...............
    ----------------------------------------------------------------------
    Ran 15 tests in 0.002s
    
    OK
    
    real	0m0.058s
    user	0m0.051s
    sys	0m0.007s
    ```

## Changes

- switch tests to unittest
- add testing to the pre-commit hook
- add testing to the github actions