### PR TITLE
SIGTERM & SIGWINCH

### DIFF
--- a/laser_prynter/pbar.py
+++ b/laser_prynter/pbar.py
@@ -169,8 +169,6 @@ class PBar:
 
         if self.is_winching:
             self.handle_resize()
-            self.is_winching = False
-            return
 
         target_pos = self._pbar_terminal_x_at(self.i + n)
 

--- a/laser_prynter/pbar.py
+++ b/laser_prynter/pbar.py
@@ -55,38 +55,23 @@ class PBar:
         sys.exit(0)
 
     def sigwinch_handler(self, _signum: int, _frame: types.FrameType | None) -> None:
-        self.w, self.h = _get_terminal_size()
         _print_to_terminal(
-            '\x1b7'  # save cursor position
-            f'\x1b[0;{self.h - 2}r'  # set top & bottom regions (margins) - reserve 2 lines
-            f'\x1b[{self.h};1000H'  # move to bottom line
-            '\r'
+            f'\x1b[0;{self.h - 1}r'  # set top & bottom regions (margins) - reserve 2 lines
+            f'\x1b[{self.h};0H'  # move to bottom line
             '\x1b[2K'  # clear entire line
-            f'\x1b[{self.h - 1};1000H'  # move to bottom line
-            '\r'
+            f'\x1b[{self.h};0H'  # move to bottom line
             '\x1b[2K'  # clear entire line
-            '\x1b8'  # restore cursor position
-            '\x1b[2A'  # move cursor up 2 lines
+            '\x1b[10A'  # move cursor up 2 lines
         )
+        self.w, self.h = _get_terminal_size()
+        self.g = RGBGradient(start=self.g.start, end=self.g.end, steps=self.w)
+        self._initial_bar()
 
-        # curr, progress = self.curr, self.progress
-        # self.curr, self.progress = 0, 0
-        # if self.t > self.w:
-        #     self.g = list(interp_xyz(self.c1, self.c2, self.t + 1))
-        # else:
-        #     self.g = list(interp_xyz(self.c1, self.c2, self.w + 1))
+        i = self.i
+        self.i, self.x_pos = 0, 0
+        self.update(i)
 
-        # self._iter_pbar = iter(self._pbar())
-
-        # self._initial_bar()
-        # self.progress = progress
-        # for _ in range(curr):
-        #     try:
-        #         next(self)
-        #     except StopIteration:
-        #         break
-
-        # self._print_info()
+        self._print_info()
 
     @staticmethod
     def randgrad() -> tuple[RGBColour, RGBColour]:

--- a/laser_prynter/pbar.py
+++ b/laser_prynter/pbar.py
@@ -186,6 +186,6 @@ class PBar:
 if __name__ == '__main__':
     with PBar(200, *PBar.randgrad()) as pbar:
         for i in range(200):
-            time.sleep(randint(int(0.01 * 100), int(0.1 * 100)) / 100)
-            print(f'-> {i}')
+            time.sleep(randint(int(0.01 * 100), int(0.2 * 100)) / 100)
+            print(f'-> {i}', flush=True)
             pbar.update(1)

--- a/laser_prynter/pbar.py
+++ b/laser_prynter/pbar.py
@@ -22,12 +22,17 @@ def _print_to_terminal(s: str) -> None:
 
 
 def _get_terminal_size() -> tuple[int, int]:
-    'Get terminal size (width, height)'
+    '''
+    Get terminal size (width, height)
+    - first try STDERR (as STDOUT is more likely to be redirected),
+    - then try STDOUT
+    - if both fail, return default (80, 24).
+    '''
     try:
-        size = os.get_terminal_size(1)
+        size = os.get_terminal_size(2)
     except OSError:
         try:
-            size = os.get_terminal_size(2)
+            size = os.get_terminal_size(1)
         except OSError:
             return (80, 24)
     return (size.columns, size.lines)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "laser-prynter"
-version = "0.6.0"
+version = "0.7.0"
 authors = [{ name = "tmck-code", email = "tmck01@gmail.com" }]
 description = "terminal/cli/python helpers for colour and pretty-printing"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "laser-prynter"
-version = "0.6.0"
+version = "0.7.0"
 source = { virtual = "." }
 dependencies = [
     { name = "pygments" },


### PR DESCRIPTION
## Context

This adds some fancier features to pbar - reacting to

- SIGTERM (control+c)
- SIGWINCH (terminal resize)

## Changes

- Use the `signal` standard library to monitor for SIGTERM and SIGWINCH
- On SIGTERM, call `reset terminal` and exit with status 0
- on SIGWINCH, call `handle resize` and redraw the info & progress bar
